### PR TITLE
Handle possibility of nil data units in min/max comparisons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    darksky_weather-api (0.2.1)
+    darksky_weather-api (0.2.2)
       activesupport
       httparty
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.0)
+    activesupport (6.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.1, >= 2.1.8)
+      zeitwerk (~> 2.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     httparty (0.17.1)
@@ -24,7 +24,7 @@ GEM
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0904)
-    minitest (5.12.2)
+    minitest (5.13.0)
     multi_xml (0.6.0)
     rake (10.5.0)
     rspec (3.8.0)
@@ -43,7 +43,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    zeitwerk (2.1.10)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby

--- a/lib/darksky_weather/api/weather_analysis.rb
+++ b/lib/darksky_weather/api/weather_analysis.rb
@@ -22,7 +22,7 @@ module DarkskyWeather
       end
 
       def max_precipitation(type: 'rain', hours: hourly)
-        hours.select{|h| h.precip_type == type  }.map{|h| h.precip_intensity }.max || 0
+        hours.select{|h| h.precip_type == type  }.map{|h| h.precip_intensity || 0.0 }.max || 0
       end
 
       def max_precipitation_datetime(type: 'rain', hours: hourly)
@@ -31,7 +31,7 @@ module DarkskyWeather
       end
 
       def max_accumulation(hours: hourly)
-        hours.map{|h| h.precip_accumulation }.max || 0
+        hours.map{|h| h.precip_accumulation || 0.0 }.max || 0
       end
 
       def max_accumulation_datetime(hours: hourly)
@@ -40,7 +40,7 @@ module DarkskyWeather
       end
 
       def worst_visibility(hours: hourly)
-        hours.map{|h| h.visibility }.min || 10
+        hours.map{|h| h.visibility || 0.0 }.min || 10
       end
 
       def worst_visibility_datetime(hours: hourly)
@@ -49,7 +49,7 @@ module DarkskyWeather
       end
 
       def best_visibility(hours: hourly)
-        hours.map{|h| h.visibility }.max || 10
+        hours.map{|h| h.visibility || 0.0 }.max || 10
       end
 
       def best_visibility_datetime(hours: hourly)
@@ -63,7 +63,7 @@ module DarkskyWeather
       end
 
       def max_temperature(hours: hourly)
-        hours.map{|h| h.temperature }.max
+        hours.map{|h| h.temperature || 0.0 }.max
       end
 
       def max_temperature_datetime(hours: hourly)
@@ -72,7 +72,7 @@ module DarkskyWeather
       end
 
       def min_temperature(hours: hourly)
-        hours.map{|h| h.temperature }.min
+        hours.map{|h| h.temperature || 0.0 }.min
       end
 
       def min_temperature_datetime(hours: hourly)
@@ -81,7 +81,7 @@ module DarkskyWeather
       end
 
       def max_wind_speed(hours: hourly)
-        hours.map{|h| h.wind_speed }.max
+        hours.map{|h| h.wind_speed || 0.0 }.max
       end
 
       def max_wind_speed_datetime(hours: hourly)
@@ -90,7 +90,7 @@ module DarkskyWeather
       end
 
       def min_wind_speed(hours: hourly)
-        hours.map{|h| h.wind_speed }.min
+        hours.map{|h| h.wind_speed || 0.0 }.min
       end
 
       def min_wind_speed_datetime(hours: hourly)
@@ -99,12 +99,12 @@ module DarkskyWeather
       end
 
       def average_wind_speed(hours: hourly)
-        total_wind_speed = hours.map{|h| h.wind_speed }.sum
+        total_wind_speed = hours.map{|h| h.wind_speed || 0.0 }.sum
         (total_wind_speed / hours.count.to_f).to_f
       end
 
       def max_wind_gust(hours: hourly)
-        hours.map{|h| h.wind_gust }.max
+        hours.map{|h| h.wind_gust || 0.0 }.max
       end
 
       def max_wind_gust_datetime(hours: hourly)


### PR DESCRIPTION
Previously, we were doing numeric comparisons against potentially nil data points. This PR fixes that issue. Updating the gem should handle this:
https://github.com/Lojistic/Auditor/issues/1026
